### PR TITLE
fix: update hooks for aio-cli-plugin-asset-compute@v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,8 +105,8 @@ class DxAssetComputeWorker1 extends Generator {
       'hooks',
       // value
       {
-        'post-app-run': 'adobe-asset-compute devtool',
-        test: 'adobe-asset-compute test-worker'
+        'post-app-run': 'adobe-asset-compute asset-compute:devtool',
+        test: 'adobe-asset-compute asset-compute:test-worker'
       }
     )
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,8 +40,8 @@ describe('prototype', () => {
 
 function assertScripts () {
   const config = yaml.load(fs.readFileSync('src/dx-asset-compute-worker-1/ext.config.yaml').toString())
-  assert.strictEqual(config.hooks.test, 'adobe-asset-compute test-worker')
-  assert.strictEqual(config.hooks['post-app-run'], 'adobe-asset-compute devtool')
+  assert.strictEqual(config.hooks.test, 'adobe-asset-compute asset-compute:test-worker')
+  assert.strictEqual(config.hooks['post-app-run'], 'adobe-asset-compute asset-compute:devtool')
 }
 
 describe('run', () => {


### PR DESCRIPTION
## Description

The plugin version at v4, uses oclif@v2, which had this quirk we relied upon, where we didn't need to specify the command topic beforehand.

## Depends on: 

1. https://github.com/adobe/generator-add-action-asset-compute/pull/3
2. https://github.com/adobe/aio-cli-plugin-asset-compute/pull/95

## How Has This Been Tested?

Pending.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
