### PR TITLE
fix: pin eslint-plugin-n to ^15.7 to support node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-jest": "^27",
-    "eslint-plugin-n": "^16.0.1",
+    "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-standard": "^5.0.0",


### PR DESCRIPTION
## Description

Version `^16.0` of `eslint-plugin-n` doesn't support Node 14, but `aio` still does. Pin to `^15.7` for now

## Related Issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
